### PR TITLE
Pre-allocate DMA buffer during display init.

### DIFF
--- a/examples/lvgl/main/CMakeLists.txt
+++ b/examples/lvgl/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 
 idf_component_register(SRCS main.c
-                       REQUIRES driver freertos esp_lcd)
+                       REQUIRES driver freertos esp_lcd esp_timer)

--- a/examples/lvgl/main/main.c
+++ b/examples/lvgl/main/main.c
@@ -8,14 +8,15 @@
 #include <driver/ledc.h>
 #include <driver/spi_master.h>
 #include <esp_err.h>
+#include <esp_freertos_hooks.h>
 #include <esp_log.h>
 #include <esp_lcd_panel_io.h>
 #include <esp_lcd_panel_vendor.h>
 #include <esp_lcd_panel_ops.h>
 #include <esp_lcd_ili9488.h>
+#include <esp_timer.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
-#include <esp_freertos_hooks.h>
 #include <lvgl.h>
 #include <stdio.h>
 #include "sdkconfig.h"

--- a/examples/lvgl/main/main.c
+++ b/examples/lvgl/main/main.c
@@ -192,7 +192,7 @@ void initialize_display()
     ESP_ERROR_CHECK(
         esp_lcd_new_panel_io_spi((esp_lcd_spi_bus_handle_t)SPI2_HOST, &io_config, &lcd_io_handle)); 
 
-    ESP_ERROR_CHECK(esp_lcd_new_panel_ili9488(lcd_io_handle, &lcd_config, &lcd_handle));
+    ESP_ERROR_CHECK(esp_lcd_new_panel_ili9488(lcd_io_handle, &lcd_config, LV_BUFFER_SIZE, &lcd_handle));
 
     ESP_ERROR_CHECK(esp_lcd_panel_reset(lcd_handle));
     ESP_ERROR_CHECK(esp_lcd_panel_init(lcd_handle));

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -2,4 +2,4 @@ dependencies:
   idf: '>=4.4.2'
 description: esp_lcd driver for ILI9488 displays
 url: https://github.com/atanisoft/esp_lcd_ili9488
-version: 1.0.6
+version: 1.0.7

--- a/include/esp_lcd_ili9488.h
+++ b/include/esp_lcd_ili9488.h
@@ -17,6 +17,7 @@ extern "C" {
  *
  * @param[in] io LCD panel IO handle
  * @param[in] panel_dev_config general panel device configuration
+ * @param[in] buffer_size size of buffer to allocate for color conversions.
  * @param[out] ret_panel Returned LCD panel handle
  * @return
  *          - ESP_ERR_INVALID_ARG   if parameter is invalid
@@ -24,13 +25,16 @@ extern "C" {
  *          - ESP_OK                on success
  * 
  * NOTE: If you are using the SPI interface you *MUST* 18-bit color mode
- * in @param panel_dev_config field bits_per_pixel.
+ * in @param panel_dev_config field bits_per_pixel and @param buffer_size
+ * must be provided.
  * 
  * NOTE: For parallel IO (Intel 8080) interface 16-bit color mode should
- * be used.
+ * be used and @param buffer_size will be ignored.
+
  */
 esp_err_t esp_lcd_new_panel_ili9488(const esp_lcd_panel_io_handle_t io,
                                     const esp_lcd_panel_dev_config_t *panel_dev_config,
+                                    const size_t buffer_size,
                                     esp_lcd_panel_handle_t *ret_panel);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixes https://github.com/atanisoft/esp_lcd_ili9488/issues/3