### PR TITLE
Debug rotation

### DIFF
--- a/esp_lcd_ili9488.c
+++ b/esp_lcd_ili9488.c
@@ -255,11 +255,11 @@ static esp_err_t panel_ili9488_mirror(
     esp_lcd_panel_io_handle_t io = ili9488->io;
     if (mirror_x)
     {
-        ili9488->memory_access_control |= LCD_CMD_MX_BIT;
+        ili9488->memory_access_control &= ~LCD_CMD_MX_BIT;
     }
     else
     {
-        ili9488->memory_access_control &= ~LCD_CMD_MX_BIT;
+        ili9488->memory_access_control |= LCD_CMD_MX_BIT;
     }
     if (mirror_y)
     {

--- a/esp_lcd_ili9488.c
+++ b/esp_lcd_ili9488.c
@@ -40,7 +40,6 @@ typedef struct
     uint8_t color_mode;
     size_t buffer_size;
     uint8_t *color_buffer;
-    uint8_t screen_orientation;
 } ili9488_panel_t;
 
 enum ili9488_constants
@@ -67,10 +66,6 @@ enum ili9488_constants
 
     ILI9488_WRITE_MODE_BCTRL_DD_ON = 0x28,
     ILI9488_FRAME_RATE_60HZ = 0xA0,
-
-    ILI9488_SET_ADDRESS_MODE = 0x36,
-    ILI9488_ORIENTATION_LANDSCAPE = 0xf8,
-    ILI9488_ORIENTATION_PORTRAIT = 0x5c,
 
     ILI9488_INIT_LENGTH_MASK = 0x1F,
     ILI9488_INIT_DONE_FLAG = 0xFF
@@ -120,6 +115,7 @@ static esp_err_t panel_ili9488_init(esp_lcd_panel_t *panel)
 {
     ili9488_panel_t *ili9488 = __containerof(panel, ili9488_panel_t, base);
     esp_lcd_panel_io_handle_t io = ili9488->io;
+
     lcd_init_cmd_t ili9488_init[] =
     {
         { ILI9488_POSITIVE_GAMMA_CTL,
@@ -145,7 +141,6 @@ static esp_err_t panel_ili9488_init(esp_lcd_panel_t *panel)
         { ILI9488_FUNCTION_CTL, { 0x02, 0x02, 0x3B }, 3},
         { ILI9488_ENTRY_MODE_CTL, { 0xC6 }, 1 },
         { ILI9488_ADJUST_CTL_THREE, { 0xA9, 0x51, 0x2C, 0x02 }, 4 },
-        { ILI9488_SET_ADDRESS_MODE, { ili9488->screen_orientation }, 1 },
         { LCD_CMD_NOP, { 0 }, ILI9488_INIT_DONE_FLAG },
     };
 
@@ -328,7 +323,6 @@ esp_err_t esp_lcd_new_panel_ili9488(
     const esp_lcd_panel_io_handle_t io,
     const esp_lcd_panel_dev_config_t *panel_dev_config,
     const size_t buffer_size,
-    bool landscape,
     esp_lcd_panel_handle_t *ret_panel)
 {
     esp_err_t ret = ESP_OK;
@@ -347,12 +341,6 @@ esp_err_t esp_lcd_new_panel_ili9488(
         cfg.mode = GPIO_MODE_OUTPUT;
         ESP_GOTO_ON_ERROR(gpio_config(&cfg), err, TAG,
                           "configure GPIO for RESET line failed");
-    }
-
-    ili9488->screen_orientation = ILI9488_ORIENTATION_PORTRAIT;
-    if (landscape)
-    {
-        ili9488->screen_orientation = ILI9488_ORIENTATION_LANDSCAPE;
     }
 
     if (panel_dev_config->bits_per_pixel == 16)

--- a/examples/lvgl/main/main.c
+++ b/examples/lvgl/main/main.c
@@ -201,7 +201,7 @@ void initialize_display()
     ESP_ERROR_CHECK(
         esp_lcd_new_panel_io_spi((esp_lcd_spi_bus_handle_t)SPI2_HOST, &io_config, &lcd_io_handle)); 
 
-    ESP_ERROR_CHECK(esp_lcd_new_panel_ili9488(lcd_io_handle, &lcd_config, LV_BUFFER_SIZE, false, &lcd_handle));
+    ESP_ERROR_CHECK(esp_lcd_new_panel_ili9488(lcd_io_handle, &lcd_config, LV_BUFFER_SIZE, &lcd_handle));
 
     ESP_ERROR_CHECK(esp_lcd_panel_reset(lcd_handle));
     ESP_ERROR_CHECK(esp_lcd_panel_init(lcd_handle));

--- a/include/esp_lcd_ili9488.h
+++ b/include/esp_lcd_ili9488.h
@@ -18,7 +18,6 @@ extern "C" {
  * @param[in] io LCD panel IO handle
  * @param[in] panel_dev_config general panel device configuration
  * @param[in] buffer_size size of buffer to allocate for color conversions.
- * @param[in] landscape create the panel in landscape mode (vs. portrait)
  * @param[out] ret_panel Returned LCD panel handle
  * @return
  *          - ESP_ERR_INVALID_ARG   if parameter is invalid
@@ -36,7 +35,6 @@ extern "C" {
 esp_err_t esp_lcd_new_panel_ili9488(const esp_lcd_panel_io_handle_t io,
                                     const esp_lcd_panel_dev_config_t *panel_dev_config,
                                     const size_t buffer_size,
-                                    bool landscape,
                                     esp_lcd_panel_handle_t *ret_panel);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Rotation now works correctly when display is initialized 'portrait'

Rotation does not work correctly when the display is initialized as landscape, however, the fact that all 4 rotations work correctly (in hardware) makes landscape initialization redundant (or at least moot). Recommend reverting the contribution that added landscape initialization.