### PR TITLE
Added comments about esp_lcd_panel_io_spi_config_t.pclk_hz

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,17 @@ At this time testing is limited to ESP32 and ESP32-S3, other ESP32 variants shou
 This driver converts the color data from 16-bit to 18-bit as part of the `draw_bitmap` callback.
 Therefore it is required to set `CONFIG_LV_COLOR_DEPTH_16=y` in your sdkconfig. In the future other
 color depths may be supported.
+
+## Screen artifacts
+
+Some developers have noted artifacts on the screen when using in their projects. This seems to be related to
+having a number of SPI devices connected to same bus or due to wire length. If this happens, try changing 
+the pclk_hz in the esp_lcd_panel_io_spi_config_t configuration to a lower value. You can try starting with 
+a small number, like 4mhz. If the artifacts disappear, try increasing this number until they appear again 
+to find a good value:
+ const esp_lcd_panel_io_spi_config_t io_config = 
+    {
+        ...
+        .pclk_hz = 4 * 1000 * 1000,
+        ...
+    }

--- a/README.md
+++ b/README.md
@@ -72,9 +72,11 @@ having a number of SPI devices connected to same bus or due to wire length. If t
 the pclk_hz in the esp_lcd_panel_io_spi_config_t configuration to a lower value. You can try starting with 
 a small number, like 4mhz. If the artifacts disappear, try increasing this number until they appear again 
 to find a good value:
+```
  const esp_lcd_panel_io_spi_config_t io_config = 
     {
         ...
         .pclk_hz = 4 * 1000 * 1000,
         ...
     }
+```

--- a/examples/lvgl/main/main.c
+++ b/examples/lvgl/main/main.c
@@ -32,7 +32,7 @@ static const int DISPLAY_VERTICAL_PIXELS = 480;
 static const int DISPLAY_COMMAND_BITS = 8;
 static const int DISPLAY_PARAMETER_BITS = 8;
 // Some developers have needed to reduce this value to avoid screen artifacts. It seems related to the # of SPI devices connected and/or wire lengths.
-// If you see artifiacts, try a low value, like 4 * 1000 * 1000, then increase until artifacts disappear.
+// If you see artifacts, try a low value, like 4 * 1000 * 1000, then increase until artifacts disappear.
 static const unsigned int DISPLAY_REFRESH_HZ = 40000000;
 static const int DISPLAY_SPI_QUEUE_LEN = 10;
 static const int SPI_MAX_TRANSFER_SIZE = 32768;

--- a/examples/lvgl/main/main.c
+++ b/examples/lvgl/main/main.c
@@ -31,6 +31,8 @@ static const int DISPLAY_HORIZONTAL_PIXELS = 320;
 static const int DISPLAY_VERTICAL_PIXELS = 480;
 static const int DISPLAY_COMMAND_BITS = 8;
 static const int DISPLAY_PARAMETER_BITS = 8;
+// Some developers have needed to reduce this value to avoid screen artifacts. It seems related to the # of SPI devices connected and/or wire lengths.
+// If you see artifiacts, try a low value, like 4 * 1000 * 1000, then increase until artifacts disappear.
 static const unsigned int DISPLAY_REFRESH_HZ = 40000000;
 static const int DISPLAY_SPI_QUEUE_LEN = 10;
 static const int SPI_MAX_TRANSFER_SIZE = 32768;


### PR DESCRIPTION
I added a comment in the example code and in the README.md about screen artifacts I was seeing using the driver. By decreasing the SPI speed, I was able to get rid of the artifacts. In my case, I have multiple devices on the same SPI bus, using Chip Select lines to pick which one to communicate to. The more devices I have on the bus, the slower I've needed to set esp_lcd_panel_io_spi_config_t.pclk_hz.