### PR TITLE
fix: add compatibility to ESP-IDF v6.0 and bump minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log for esp_lcd_ili9488
 
+## v1.1.0 – Add ESP-IDF v6.0 Compatibility
+
+* Added conditional inclusion of `esp_driver_ledc` in the main component **REQUIRES** list for ESP-IDF >= v6.0.
+* Updated `esp_lcd_new_panel_ili9488` to handle the ESP-IDF v6.0 color-order API change (`color_space` -> `rgb_ele_order`).
 
 ## v1.0.11 - Updates to LVGL examples
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,4 +8,4 @@ cmake_minimum_required(VERSION 3.20)
 
 idf_component_register(SRCS "esp_lcd_ili9488.c"
                        INCLUDE_DIRS "include"
-                       REQUIRES "driver esp_lcd")
+                       REQUIRES "driver esp_lcd esp_driver_ledc")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,12 @@
 
 cmake_minimum_required(VERSION 3.20)
 
+set(requires "driver freertos esp_lcd esp_timer")
+
+if(IDF_VERSION_MAJOR GREATER_EQUAL 6)
+    list(APPEND requires "esp_driver_ledc")
+endif()
+
 idf_component_register(SRCS "esp_lcd_ili9488.c"
                        INCLUDE_DIRS "include"
-                       REQUIRES "driver esp_lcd esp_driver_ledc")
+                       REQUIRES ${requires})

--- a/esp_lcd_ili9488.c
+++ b/esp_lcd_ili9488.c
@@ -367,6 +367,8 @@ esp_err_t esp_lcd_new_panel_ili9488(
     }
 
     ili9488->memory_access_control = LCD_CMD_MX_BIT | LCD_CMD_BGR_BIT;
+
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
     switch (panel_dev_config->color_space)
     {
         case ESP_LCD_COLOR_SPACE_RGB:
@@ -380,6 +382,21 @@ esp_err_t esp_lcd_new_panel_ili9488(
             ESP_GOTO_ON_FALSE(false, ESP_ERR_INVALID_ARG, err, TAG,
                               "Unsupported color mode!");
     }
+#else
+    switch (panel_dev_config->rgb_ele_order)
+    {
+    case LCD_RGB_ELEMENT_ORDER_RGB:
+            ESP_LOGI(TAG, "Configuring for RGB color order");
+            ili9488->memory_access_control &= ~LCD_CMD_BGR_BIT;
+            break;
+    case LCD_RGB_ELEMENT_ORDER_BGR:
+            ESP_LOGI(TAG, "Configuring for BGR color order");
+            break;
+        default:
+            ESP_GOTO_ON_FALSE(false, ESP_ERR_INVALID_ARG, err, TAG,
+                              "Unsupported color mode!");
+    }
+#endif
 
     ili9488->io = io;
     ili9488->reset_gpio_num = panel_dev_config->reset_gpio_num;

--- a/examples/lvgl/main/idf_component.yml
+++ b/examples/lvgl/main/idf_component.yml
@@ -2,5 +2,5 @@ dependencies:
   idf: ">=4.4.2"
   lvgl/lvgl: "<9.0.0"
   esp_lcd_ili9488:
-    version: "~1.0.0"
+    version: "~1.1.0"
     override_path: "../../.."

--- a/examples/lvgl/main/main.c
+++ b/examples/lvgl/main/main.c
@@ -216,7 +216,11 @@ void initialize_display()
     const esp_lcd_panel_dev_config_t lcd_config = 
     {
         .reset_gpio_num = TFT_RESET,
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
         .color_space = TFT_COLOR_MODE,
+#else
+        .rgb_ele_order = TFT_COLOR_MODE,
+#endif
         .bits_per_pixel = 18,
         .flags =
         {

--- a/examples/lvgl/main/main.c
+++ b/examples/lvgl/main/main.c
@@ -56,7 +56,12 @@ static const gpio_num_t TFT_BACKLIGHT = GPIO_NUM_18;
 #else
 #error Unsure which GPIO to use for SPI/TFT, please update code accordingly.
 #endif
+
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 0)
+static const lcd_rgb_element_order_t TFT_COLOR_MODE = LCD_RGB_ELEMENT_ORDER_BGR;
+#else
 static const lcd_rgb_element_order_t TFT_COLOR_MODE = COLOR_RGB_ELEMENT_ORDER_BGR;
+#endif
 
 // Default to 25 lines of color data
 static const size_t LV_BUFFER_SIZE = DISPLAY_HORIZONTAL_PIXELS * 25;

--- a/examples/lvgl_for_i8080/main/idf_component.yml
+++ b/examples/lvgl_for_i8080/main/idf_component.yml
@@ -2,5 +2,5 @@ dependencies:
   idf: ">=4.4.2"
   lvgl/lvgl: "~8.3.0"
   esp_lcd_ili9488:
-    version: "~1.0.0"
+    version: "~1.1.0"
     override_path: "../../.."

--- a/examples/lvgl_for_i8080/main/lvgl_example_main.c
+++ b/examples/lvgl_for_i8080/main/lvgl_example_main.c
@@ -154,7 +154,11 @@ void app_main(void)
     esp_lcd_panel_handle_t panel_handle = NULL;
     esp_lcd_panel_dev_config_t panel_config = {
         .reset_gpio_num = EXAMPLE_PIN_NUM_RST,
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
         .color_space = ESP_LCD_COLOR_SPACE_RGB,
+#else
+        .rgb_ele_order = COLOR_SPACE_RGB,
+#endif
         .bits_per_pixel = 16,
     };
     ESP_ERROR_CHECK(esp_lcd_new_panel_ili9488(io_handle, &panel_config,EXAMPLE_LCD_H_RES * 20 * sizeof(lv_color_t), &panel_handle));

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -2,4 +2,4 @@ dependencies:
   idf: '>=4.4.2'
 description: esp_lcd driver for ILI9488 displays
 url: https://github.com/atanisoft/esp_lcd_ili9488
-version: 1.0.11
+version: 1.1.0


### PR DESCRIPTION
Just some version checks around breaking changes to the `esp_lcd_panel_dev.h API in ESP-IDF v6.0